### PR TITLE
Change clearpass-api project name in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "clearpass-api"
+name = "clearpass"
 dynamic = ["version"]
 dependencies = [
        "requests",


### PR DESCRIPTION
Changing the name of the `clearpass-api` project in `pyproject.toml` to simply: `clearpass`

Hopeful this will resolve import issues up on SOAR.