### PR TITLE
Revise support dates and Python version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A simple client for Aruba Clearpass that allows enabling, disabling, and queryin
 
 This product is supported by the Cybersecurity Development Team at the University of Illinois on a best-effort basis.
 
-As of the last update to this README, the expected End-of-Life and End-of-Support dates of this product are October 2025.
+As of the last update to this README, the expected End-of-Life and End-of-Support dates of this product are October 2029.
 
 End-of-Life was decided upon based on these dependencies:
 
-    - Python 3.9 (31 October 2025)
+    - Python 3.13 (31 October 2029)
 
 
 ## Endpoint Connections


### PR DESCRIPTION
Updated End-of-Life and End-of-Support dates to October 2029 and changed Python dependency version to 3.13.

Closes #34 